### PR TITLE
Return generic home result in specific methods

### DIFF
--- a/sardana_icepap/macro/homming.py
+++ b/sardana_icepap/macro/homming.py
@@ -173,15 +173,15 @@ def home(macro, motorsInfoList, group=False, strict=False):
 
 
 def home_group_strict(macro, motorsInfoList):
-    home(macro, motorsInfoList, group=True, strict=True)
+    return home(macro, motorsInfoList, group=True, strict=True)
 
 
 def home_group(macro, motorsInfoList):
-    home(macro, motorsInfoList, group=True, strict=False)
+    return home(macro, motorsInfoList, group=True, strict=False)
 
 
 def home_strict(macro, motorsInfoList):
-    home(macro, motorsInfoList, group=False, strict=True)
+    return home(macro, motorsInfoList, group=False, strict=True)
 
 
 class ipap_homing(Macro):


### PR DESCRIPTION
Before refactoring the homing methods the specific methods like home_group
were returning the homing result. Bring back this behavior for backwards compatibility.