### PR TITLE
Add trigger/gate multiplexor mode support

### DIFF
--- a/sardana_icepap/ctrl/IcePAPTriggerController.py
+++ b/sardana_icepap/ctrl/IcePAPTriggerController.py
@@ -208,26 +208,6 @@ class IcePAPTriggerController(TriggerGateController):
         self._log.debug('AbortOne(%d): entering...' % axis)
         self._set_out(out=LOW)
 
-    def SetAxisPar(self, axis, name, value):
-        idx = axis - 1
-        tg = self.triggers[idx]
-        name = name.lower()
-        pars = ['offset', 'passive_interval', 'repetitions', 'sign',
-                'info_channels']
-        if name in pars:
-            tg[name] = value
-
-    def GetAxisPar(self, axis, name):
-        idx = axis - 1
-        tg = self.triggers[idx]
-        name = name.lower()
-        v = tg.get(name, None)
-        if v is None:
-            msg = ('GetAxisPar(%d). The parameter %s does not exist.'
-                   % (axis, name))
-            self._log.error(msg)
-        return v
-
     def SynchOne(self, axis, configuration):
         # TODO: implement the configuration for multiples configuration
         synch_group = configuration[0]

--- a/sardana_icepap/ctrl/IcePAPTriggerController.py
+++ b/sardana_icepap/ctrl/IcePAPTriggerController.py
@@ -140,14 +140,9 @@ class IcePAPTriggerController(TriggerGateController):
         if id_ == self._last_id:
             return
 
-        # TODO: Implement verification of the motor if it is part of the
-        #  controller.
-
         self._last_id = id_
-        # TODO: wait for design decissions in multiplexor trigger/gate mode: 
-        # - SynchOne values in position domain are in user or dial units?
-        # - trigger/gate will have their own conversion factor?
-        # See more details in sardana#1678
+        # this is a bit hacky, ideally we could define an extra attribute
+        # step_per_unit (would require updating it at the same time as the motor's one)
         motor_name = "motor/{}/{}".format(self._ipap_ctrl.alias(), id_)
         motor = taurus.Device(motor_name)
         self._motor_axis = id_

--- a/sardana_icepap/ctrl/IcePAPTriggerController.py
+++ b/sardana_icepap/ctrl/IcePAPTriggerController.py
@@ -124,8 +124,6 @@ class IcePAPTriggerController(TriggerGateController):
         self._last_id = None
         self._motor_axis = None
         self._motor_spu = 1
-        self._motor_offset = 0
-        self._motor_sign = 1
 
     def _set_out(self, out=LOW):
         motor = self._ipap[self._motor_axis]
@@ -152,10 +150,8 @@ class IcePAPTriggerController(TriggerGateController):
         # See more details in sardana#1678
         motor_name = "motor/{}/{}".format(self._ipap_ctrl.alias(), id_)
         motor = taurus.Device(motor_name)
-        self._motor_axis = int(motor.get_property('axis')['axis'][0])
-        attrs = motor.read_attributes(['step_per_unit', 'offset', 'sign'])
-        values = [attr.value for attr in attrs]
-        self._motor_spu, self._motor_offset, self._motor_sign = values
+        self._motor_axis = id_
+        self._motor_spu = motor.read_attribute('step_per_unit').value
 
         if self._use_master_out:
             # remove previous connection and connect the new motor
@@ -257,9 +253,8 @@ class IcePAPTriggerController(TriggerGateController):
         start_user = synch_group[SynchParam.Initial][SynchDomain.Position]
         delta_user = synch_group[SynchParam.Total][SynchDomain.Position]
 
-        start_user -= self._motor_offset
-        start = start_user * self._motor_spu/self._motor_sign
-        delta = delta_user * self._motor_spu/self._motor_sign
+        start = start_user * self._motor_spu
+        delta = delta_user * self._motor_spu
 
         end = start + delta * nr_points
         self._log.debug('IcepapTriggerCtr configuration: %f %f %d %d' %


### PR DESCRIPTION
This PR assumes [Sardana implements trigger/gate multiplexor mode](https://gitlab.com/sardana-org/sardana/-/merge_requests/1713).

Added:
- multiplexor configuration using `active_input` axis parameter 

Removed:
- `DefaultMotor` controller property
- unused `SetAxisPar()` and `GetAxisPar()` methods

Changed:
- Expect dial position in `SynchOne()`
- Adapt to new API of `StartOne()` and `PreStartOne()`

I think that this controller does not remove the synchronization configuration after the measurement process and IMO it should be done. Imagine moving the motor in parallel to the, but not part of the, measurement process. But I would treat it out to the scope of this PR.