### PR TITLE
moved _configureMotor return to after the values updated

### DIFF
--- a/sardana_icepap/ctrl/IcePAPTriggerController.py
+++ b/sardana_icepap/ctrl/IcePAPTriggerController.py
@@ -145,9 +145,6 @@ class IcePAPTriggerController(TriggerGateController):
         if motor_name is None:
             motor_name = self.DefaultMotor
 
-        if motor_name == self._last_motor_name:
-            return
-
         # TODO: Implement verification of the motor if it is part of the
         #  controller.
 
@@ -157,6 +154,9 @@ class IcePAPTriggerController(TriggerGateController):
         attrs = motor.read_attributes(['step_per_unit', 'offset', 'sign'])
         values = [attr.value for attr in attrs]
         self._motor_spu, self._motor_offset, self._motor_sign = values
+
+        if motor_name == self._last_motor_name:
+            return
 
         if self._use_master_out:
             # remove previous connection and connect the new motor


### PR DESCRIPTION
There was an issue in BL16 where the user would change the offset of the motor and the following scan macro wouldn't execute correctly. This was caused because of an early return statement which prevented the update of the values from the motor in the controller. This is solved by moving the return statement to after the values update. 
Needs to be checked for side effects.