### PR TITLE
fix test imports

### DIFF
--- a/tests/test_esync_macro.py
+++ b/tests/test_esync_macro.py
@@ -34,7 +34,7 @@ def motor(mocker):
 @pytest.fixture
 def esync(mocker):
     mocker.patch("sardana.macroserver.macro.Type")
-    from sardana_icepap.macro import esync
+    from sardana_icepap.macro.esync import ipap_esync
 
     mocker.patch.object(ipap_esync, "door", return_value="macro")
     mocker.patch.object(ipap_esync, "parent_macro", return_value="macro")


### PR DESCRIPTION
```bash
====================================================== test session starts =======================================================
platform linux -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /mxn/home/aurfre/sardana-icepap
plugins: mock-3.8.2
collected 12 items

tests/test_esync_macro.py ............                                                                                     [100%]

======================================================== warnings summary ========================================================
../../../../opt/conda/envs/sardana/lib/python3.9/site-packages/tango/utils.py:181
  /opt/conda/envs/sardana/lib/python3.9/site-packages/tango/utils.py:181: DeprecationWarning: `np.str` is a deprecated alias for the builtin `str`. To silence this warning, use `str` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    CmdArgType.DevString: numpy.str,

tests/test_esync_macro.py::test_not_icepap
  /opt/conda/envs/sardana/lib/python3.9/site-packages/future/standard_library/__init__.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

tests/test_esync_macro.py::test_not_icepap
  /opt/conda/envs/sardana/lib/python3.9/site-packages/taurus/core/tango/enums.py:82: DeprecationWarning: `np.str` is a deprecated alias for the builtin `str`. To silence this warning, use `str` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    PyTango.DevString: numpy.str,

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================= 12 passed, 3 warnings in 2.80s =================================================
```